### PR TITLE
Add option to account for n-gram vector norm during pruning

### DIFF
--- a/compress_fasttext/compress.py
+++ b/compress_fasttext/compress.py
@@ -66,11 +66,12 @@ def prune_ft_freq(
         pq=True,
         qdim=100,
         centroids=255,
-        prune_by_norm=True):
+        prune_by_norm=True,
+        norm_power=1):
 
     if prune_by_norm:
         ngram_norms = np.linalg.norm(ft.vectors_ngrams, axis=-1)
-        scorer = lambda id, count: count * ngram_norms[id]
+        scorer = lambda id, count: count * (ngram_norms[id] ** norm_power)
     else:
         scorer = lambda id, count: count
 

--- a/compress_fasttext/compress.py
+++ b/compress_fasttext/compress.py
@@ -58,9 +58,24 @@ def prune_ft(ft, new_vocab_size=1_000, new_ngrams_size=20_000, fp16=True):
     )
 
 
-def prune_ft_freq(ft, new_vocab_size=20_000, new_ngrams_size=100_000, fp16=True, pq=True, qdim=100, centroids=255):
+def prune_ft_freq(
+        ft,
+        new_vocab_size=20_000,
+        new_ngrams_size=100_000,
+        fp16=True,
+        pq=True,
+        qdim=100,
+        centroids=255,
+        prune_by_norm=True):
+
+    if prune_by_norm:
+        ngram_norms = np.linalg.norm(ft.vectors_ngrams, axis=-1)
+        scorer = lambda id, count: count * ngram_norms[id]
+    else:
+        scorer = lambda id, count: count
+
     new_to_old_buckets, old_hash_count = count_buckets(ft, list(ft.vocab.keys()), new_ngrams_size=new_ngrams_size)
-    id_and_count = sorted(old_hash_count.items(), key=lambda x: x[1], reverse=True)
+    id_and_count = sorted(old_hash_count.items(), key=lambda x: scorer(*x), reverse=True)
     ids = [x[0] for x in id_and_count[:new_ngrams_size]]
     top_ngram_vecs = ft.vectors_ngrams[ids]
     if pq and len(top_ngram_vecs) > 0:


### PR DESCRIPTION
Эти изменения позволяют учесть нормы векторов n-грамм при сокращении словаря.

При установке `prune_by_norm=True` метрики растут для всех моделей, которые я смотрел, поэтому он включен по умолчанию. У меня не хватило терпения проверить все 48 моделей, поэтому вот таблица со средними результатами evaluate_all моделей, которые получилось измерить:

model | prune_by_norm=False | prune_by_norm=True
----- | ------------------- | ------------------
ft_freqprune_100K_20K_pq_100.bin | 0.967 | 0.973
ft_freqprune_50K_20K_pq_100.bin | 0.953 | 0.964
ft_freqprune_50K_5K_pq_100.bin | 0.893 | 0.912