### PR TITLE
Gensim 4

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,16 @@
 # Compress-fastText
 This Python 3 package allows to compress fastText word embedding models 
 (from the `gensim` package) by orders of magnitude, 
-without seriously affecting their quality. It can be installed with `pip`:
+without seriously affecting their quality. 
+
+**Note: gensim==4.0.0 has introduced some backward-incompatible changes:**
+* With gensim<4.0.0, please use compress-fasttext<=0.0.7 
+(and optionally Russian models from [our first release](https://github.com/avidale/compress-fasttext/releases/tag/v0.0.1)).
+* With gensim>=4.0.0, please use compress-fasttext>=0.1.0
+(and optionally Russian or English models from [our 0.1.0 release](https://github.com/avidale/compress-fasttext/releases/tag/v0.1.0)).
+
+
+The package can be installed with `pip`:
 ```commandline
 pip install compress-fasttext[full]
 ```

--- a/README.md
+++ b/README.md
@@ -1,14 +1,17 @@
 # Compress-fastText
 This Python 3 package allows to compress fastText word embedding models 
 (from the `gensim` package) by orders of magnitude, 
-without seriously affecting their quality. 
+without significantly affecting their quality. 
 
 **Note: gensim==4.0.0 has introduced some backward-incompatible changes:**
 * With gensim<4.0.0, please use compress-fasttext<=0.0.7 
 (and optionally Russian models from [our first release](https://github.com/avidale/compress-fasttext/releases/tag/v0.0.1)).
 * With gensim>=4.0.0, please use compress-fasttext>=0.1.0
 (and optionally Russian or English models from [our 0.1.0 release](https://github.com/avidale/compress-fasttext/releases/tag/v0.1.0)).
-* Some models are supported by both versions of gensim+compress-fasttext; this should be determined experimentally.
+* Some models are no longer supported in the new version of gensim+compress-fasttext 
+  (for example, multiple models from [RusVectores](https://rusvectores.org/ru/models/) that use `compatible_hash=False`). 
+* For any particular model, compatibility should be determined experimentally. 
+  If you notice any strange behaviour, please report in the Github issues.
 
 
 The package can be installed with `pip`:
@@ -70,9 +73,9 @@ small_model = compress_fasttext.models.CompressedFastTextKeyedVectors.load(
     'https://github.com/avidale/compress-fasttext/releases/download/gensim-4-draft/geowac_tokens_sg_300_5_2020-100K-20K-100.bin'
 )
 print(small_model['спасибо'])
-# [ 1.22736421e-01 -3.21375653e-01 ...  4.33826083e-01] # a 300-dimensional vector
+# [ 0.26762889  0.35489027 ...  -0.06149674] # a 300-dimensional vector
 print(small_model.most_similar('котенок'))
-# [('щенок', 0.659467875957489), ('кот', 0.5826340913772583), ... ]
+# [('кот', 0.7391024827957153), ('пес', 0.7388300895690918), ('малыш', 0.7280327081680298), ... ]
 ```
 The class `CompressedFastTextKeyedVectors` inherits from `gensim.models.fasttext.FastTextKeyedVectors`, 
 but makes a few additional optimizations.

--- a/README.md
+++ b/README.md
@@ -8,6 +8,7 @@ without seriously affecting their quality.
 (and optionally Russian models from [our first release](https://github.com/avidale/compress-fasttext/releases/tag/v0.0.1)).
 * With gensim>=4.0.0, please use compress-fasttext>=0.1.0
 (and optionally Russian or English models from [our 0.1.0 release](https://github.com/avidale/compress-fasttext/releases/tag/v0.1.0)).
+* Some models are supported by both versions of gensim+compress-fasttext; this should be determined experimentally.
 
 
 The package can be installed with `pip`:
@@ -56,20 +57,20 @@ The recommended approach is combination of feature selection and quantization (`
 
 ### Model usage
 If you just need a tiny fastText model for Russian, you can download 
-[this](https://github.com/avidale/compress-fasttext/releases/download/v0.0.1/ft_freqprune_100K_20K_pq_100.bin)
-28-megabyte model. It's a compressed version of 
-[ruscorpora_none_fasttextskipgram_300_2_2019](http://vectors.nlpl.eu/repository/20/181.zip) model
+[this](https://github.com/avidale/compress-fasttext/releases/download/gensim-4-draft/geowac_tokens_sg_300_5_2020-100K-20K-100.bin)
+21-megabyte model. It's a compressed version of 
+[geowac_tokens_none_fasttextskipgram_300_5_2020](http://vectors.nlpl.eu/repository/20/214.zip) model
 from [RusVectores](https://rusvectores.org/ru/models/).
 
 If `compress-fasttext` is already installed, you can download and use this tiny model
 ```python
 import compress_fasttext
 small_model = compress_fasttext.models.CompressedFastTextKeyedVectors.load(
-    'https://github.com/avidale/compress-fasttext/releases/download/v0.0.1/ft_freqprune_100K_20K_pq_100.bin'
+    'https://github.com/avidale/compress-fasttext/releases/download/gensim-4-draft/geowac_tokens_sg_300_5_2020-100K-20K-100.bin'
 )
 print(small_model['спасибо'])
 ```
-The class `CompressedFastTextKeyedVectors` inherits from `gensim.models.keyed_vectors.FastTextKeyedVectors`, 
+The class `CompressedFastTextKeyedVectors` inherits from `gensim.models.fasttext.FastTextKeyedVectors`, 
 but makes a few additional optimizations.
 
 ### Notes

--- a/compress_fasttext/compress.py
+++ b/compress_fasttext/compress.py
@@ -15,27 +15,24 @@ def make_new_fasttext_model(
         new_vectors,
         new_vectors_ngrams,
         new_vocab=None,
-        add_index2entity=True,
         cls=None,
 ):
-    cls = cls or gensim.models.keyedvectors.FastTextKeyedVectors
+    cls = cls or gensim.models.fasttext.FastTextKeyedVectors
     new_ft = cls(
         vector_size=ft.vector_size,
         min_n=ft.min_n,
         max_n=ft.max_n,
         bucket=new_vectors_ngrams.shape[0],
-        compatible_hash=ft.compatible_hash
     )
     new_ft.vectors_vocab = None  # if we don't fine tune the model we don't need these vectors
     new_ft.vectors = new_vectors  # quantized vectors top_vectors
     if new_vocab is None:
-        new_ft.vocab = ft.vocab
+        new_ft.key_to_index = ft.key_to_index
     else:
-        new_ft.vocab = new_vocab
+        new_ft.key_to_index = new_vocab
     new_ft.vectors_ngrams = new_vectors_ngrams
-    if add_index2entity:  # this is required for methods such as most_similar()
-        inverse_index = {value.index: key for key, value in new_ft.vocab.items()}
-        new_ft.index2entity = [inverse_index.get(i) for i in range(len(new_ft.vocab))]
+    if hasattr(new_ft, 'update_index2word'):
+        new_ft.update_index2word()
     return new_ft
 
 
@@ -82,8 +79,8 @@ def prune_ft_freq(
         qdim=100,
         centroids=255,
         prune_by_norm=True,
-        norm_power=1):
-
+        norm_power=1,
+):
     if prune_by_norm:
         ngram_norms = np.linalg.norm(ft.vectors_ngrams, axis=-1)
         scorer = lambda id, count: count * (ngram_norms[id] ** norm_power)
@@ -91,10 +88,12 @@ def prune_ft_freq(
         scorer = lambda id, count: count
 
     logger.info('quantizing ngrams...')
-    new_to_old_buckets, old_hash_count = count_buckets(ft, list(ft.vocab.keys()), new_ngrams_size=new_ngrams_size)
+    new_to_old_buckets, old_hash_count = count_buckets(
+        ft, list(ft.vocab.keys()), new_ngrams_size=new_ngrams_size,
+    )
     logger.info('old ngrams in use: {}'.format(len(old_hash_count)))
     id_and_count = sorted(old_hash_count.items(), key=lambda x: scorer(*x), reverse=True)
-    ids = [x[0] for x in id_and_count[:new_ngrams_size]]
+    ids = [x[0] for x in id_and_count[:new_ngrams_size]]  # todo: adapt for the case of chaning hash function
     top_ngram_vecs = ft.vectors_ngrams[ids]
     if pq and len(top_ngram_vecs) > 0:
         top_ngram_vecs = quantize(top_ngram_vecs, qdim=qdim, centroids=centroids)

--- a/compress_fasttext/compress.py
+++ b/compress_fasttext/compress.py
@@ -93,7 +93,7 @@ def prune_ft_freq(
     )
     logger.info('old ngrams in use: {}'.format(len(old_hash_count)))
     id_and_count = sorted(old_hash_count.items(), key=lambda x: scorer(*x), reverse=True)
-    ids = [x[0] for x in id_and_count[:new_ngrams_size]]  # todo: adapt for the case of chaning hash function
+    ids = [x[0] for x in id_and_count[:new_ngrams_size]]
     top_ngram_vecs = ft.vectors_ngrams[ids]
     if pq and len(top_ngram_vecs) > 0:
         top_ngram_vecs = quantize(top_ngram_vecs, qdim=qdim, centroids=centroids)

--- a/compress_fasttext/compress.py
+++ b/compress_fasttext/compress.py
@@ -89,7 +89,7 @@ def prune_ft_freq(
 
     logger.info('quantizing ngrams...')
     new_to_old_buckets, old_hash_count = count_buckets(
-        ft, list(ft.vocab.keys()), new_ngrams_size=new_ngrams_size,
+        ft, list(ft.key_to_index.keys()), new_ngrams_size=new_ngrams_size,
     )
     logger.info('old ngrams in use: {}'.format(len(old_hash_count)))
     id_and_count = sorted(old_hash_count.items(), key=lambda x: scorer(*x), reverse=True)

--- a/compress_fasttext/models.py
+++ b/compress_fasttext/models.py
@@ -58,7 +58,7 @@ class CompressedFastTextKeyedVectors(FastTextKeyedVectors):
             If word and all ngrams not in vocabulary.
 
         """
-        if word in self.vocab:
+        if word in self.key_to_index:
             return super(FastTextKeyedVectors, self).word_vec(word, use_norm)
         elif self.bucket == 0:
             raise KeyError('cannot calculate vector for OOV word without ngrams')

--- a/compress_fasttext/models.py
+++ b/compress_fasttext/models.py
@@ -1,7 +1,7 @@
 import numpy as np
 
-from gensim.models.keyedvectors import FastTextKeyedVectors
-from gensim.models.utils_any2vec import ft_ngram_hashes
+from gensim.models.fasttext import FastTextKeyedVectors
+from .utils import ft_ngram_hashes
 
 
 from compress_fasttext.compress import make_new_fasttext_model
@@ -32,6 +32,7 @@ class CompressedFastTextKeyedVectors(FastTextKeyedVectors):
         )
 
     def update_index2word(self):
+        # todo: use the new GenSim https://github.com/RaRe-Technologies/gensim/wiki/Migrating-from-Gensim-3.x-to-4
         if not self.index2word:
             inverse_index = {value.index: key for key, value in self.vocab.items()}
             self.index2word = [inverse_index.get(i) for i in range(len(self.vocab))]

--- a/compress_fasttext/models.py
+++ b/compress_fasttext/models.py
@@ -1,4 +1,5 @@
 import numpy as np
+import warnings
 
 from gensim.models.fasttext import FastTextKeyedVectors
 from .utils import ft_ngram_hashes
@@ -22,7 +23,15 @@ class CompressedFastTextKeyedVectors(FastTextKeyedVectors):
 
     @classmethod
     def load(cls, *args, **kwargs):
-        loaded = super(CompressedFastTextKeyedVectors, cls).load(*args, **kwargs)
+        try:
+            loaded = super(CompressedFastTextKeyedVectors, cls).load(*args, **kwargs)
+        except Exception as e:
+            warnings.warn(
+                'You seem to be loading an old model (compressed with gensim<4.0.0, compress-fasttext<0.1.0) '
+                'within an new environment (gensim>=4.0.0, compress-fasttext>=0.1.0), which may not work. '
+                'Please downgrade the packages or re-compress the model within the new environment.'
+            )
+            raise e
         # print(loaded.__dict__)
         return make_new_fasttext_model(
             loaded,

--- a/compress_fasttext/models.py
+++ b/compress_fasttext/models.py
@@ -23,19 +23,19 @@ class CompressedFastTextKeyedVectors(FastTextKeyedVectors):
     @classmethod
     def load(cls, *args, **kwargs):
         loaded = super(CompressedFastTextKeyedVectors, cls).load(*args, **kwargs)
+        # print(loaded.__dict__)
         return make_new_fasttext_model(
             loaded,
             new_vectors=loaded.vectors,
             new_vectors_ngrams=loaded.vectors_ngrams,
-            new_vocab=loaded.vocab,
+            new_vocab=loaded.key_to_index,
             cls=cls,
         )
 
     def update_index2word(self):
-        # todo: use the new GenSim https://github.com/RaRe-Technologies/gensim/wiki/Migrating-from-Gensim-3.x-to-4
-        if not self.index2word:
-            inverse_index = {value.index: key for key, value in self.vocab.items()}
-            self.index2word = [inverse_index.get(i) for i in range(len(self.vocab))]
+        if not self.index_to_key:
+            inverse_index = {value: key for key, value in self.key_to_index.items()}
+            self.index_to_key = [inverse_index.get(i) for i in range(len(self.key_to_index))]
 
     def word_vec(self, word, use_norm=False):
         """Get `word` representations in vector space, as a 1D numpy array.
@@ -64,7 +64,7 @@ class CompressedFastTextKeyedVectors(FastTextKeyedVectors):
             raise KeyError('cannot calculate vector for OOV word without ngrams')
         else:
             word_vec = np.zeros(self.vectors_ngrams.shape[1], dtype=np.float32)
-            ngram_hashes = ft_ngram_hashes(word, self.min_n, self.max_n, self.bucket, self.compatible_hash)
+            ngram_hashes = ft_ngram_hashes(word=word, minn=self.min_n, maxn=self.max_n, num_buckets=self.bucket)
             if len(ngram_hashes) == 0:
                 return word_vec
             for nh in ngram_hashes:
@@ -73,6 +73,18 @@ class CompressedFastTextKeyedVectors(FastTextKeyedVectors):
             if use_norm:
                 result /= np.sqrt(max(sum(result ** 2), EPSILON))
             return result
+
+    def fill_norms(self, force=False):
+        """
+        Ensure per-vector norms are available.
+
+        Any code which modifies vectors should ensure the accompanying norms are
+        either recalculated or 'None', to trigger a full recalculation later on-request.
+
+        """
+        if self.norms is None or force:
+            # self.norms = np.linalg.norm(self.vectors, axis=1)
+            self.norms = np.stack([sum(self.vectors[i]**2) ** 0.5 for i in range(len(self.vectors))])
 
     def init_sims(self, replace=False):
         """Precompute L2-normalized vectors.

--- a/compress_fasttext/navec_like.py
+++ b/compress_fasttext/navec_like.py
@@ -73,7 +73,10 @@ class PQ(Record):
     def __getitem__(self, id):
         indexes = self.indexes[id]
         parts = self.codes[self.qdims, indexes]
-        return parts.reshape(self.dim)
+        if len(parts.shape) == 2:
+            return parts.reshape(self.dim)
+        else:  # the index has been list or slice
+            return parts.reshape(parts.shape[0], self.dim)
 
     def __add__(self, other):
         return self.unpack() + other
@@ -130,3 +133,6 @@ class PQ(Record):
     @classmethod
     def index_type(cls, centroids):
         return np.uint8 if centroids <= 255 else np.uint16
+
+    def __len__(self):
+        return self.vectors

--- a/compress_fasttext/prune.py
+++ b/compress_fasttext/prune.py
@@ -11,9 +11,8 @@ def count_buckets(ft, words, new_ngrams_size):
     new_to_old_buckets = defaultdict(set)
     old_hash_count = defaultdict(int)
     for word in words:
-        old_hashes = ft_ngram_hashes(word, ft.min_n, ft.max_n, ft.bucket, fb_compatible=ft.compatible_hash)
-        new_hashes = ft_ngram_hashes(word, ft.min_n, ft.max_n, new_ngrams_size, fb_compatible=ft.compatible_hash)
-
+        old_hashes = ft_ngram_hashes(word=word, minn=ft.min_n, maxn=ft.max_n, num_buckets=ft.bucket)
+        new_hashes = ft_ngram_hashes(word=word, minn=ft.min_n, maxn=ft.max_n, num_buckets=new_ngrams_size)
         for old_hash in old_hashes:
             old_hash_count[old_hash] += 1  # calculate frequency of ngrams for proper weighting
 
@@ -32,7 +31,9 @@ def fasttext_like_init(n, dim=300, random_state=42):
 
 def prune_ngrams(ft, new_ngrams_size, random_state=42):
     """ Reduce the size of fasttext ngrams matrix by collapsing some hashes together """
-    new_to_old_buckets, old_hash_count = count_buckets(ft, ft.vocab.keys(), new_ngrams_size)
+    new_to_old_buckets, old_hash_count = count_buckets(
+        ft, ft.vocab.keys(), new_ngrams_size
+    )
 
     # initialize new buckets just like in fasttext
     new_ngrams = fasttext_like_init(n=new_ngrams_size, dim=ft.vectors_ngrams.shape[1], random_state=random_state)

--- a/compress_fasttext/prune.py
+++ b/compress_fasttext/prune.py
@@ -4,7 +4,7 @@ import numpy as np
 
 from collections import defaultdict
 from copy import deepcopy
-from gensim.models.utils_any2vec import ft_ngram_hashes
+from .utils import ft_ngram_hashes
 
 
 def count_buckets(ft, words, new_ngrams_size):

--- a/compress_fasttext/prune.py
+++ b/compress_fasttext/prune.py
@@ -32,7 +32,7 @@ def fasttext_like_init(n, dim=300, random_state=42):
 def prune_ngrams(ft, new_ngrams_size, random_state=42):
     """ Reduce the size of fasttext ngrams matrix by collapsing some hashes together """
     new_to_old_buckets, old_hash_count = count_buckets(
-        ft, ft.vocab.keys(), new_ngrams_size
+        ft, ft.key_to_index.keys(), new_ngrams_size
     )
 
     # initialize new buckets just like in fasttext
@@ -51,12 +51,11 @@ def prune_ngrams(ft, new_ngrams_size, random_state=42):
 
 
 def prune_vocab(ft, new_vocab_size=1_000):
-    sorted_vocab = sorted(ft.vocab.items(), key=lambda x: x[1].count, reverse=True)
+    sorted_vocab = sorted(ft.key_to_index.items(), key=lambda x: ft.get_vecattr(x[0], 'count'), reverse=True)
     top_vocab_list = deepcopy(sorted_vocab[:new_vocab_size])
     top_vector_ids = []
-    for new_index, (word, vocab_item) in enumerate(top_vocab_list):
-        top_vector_ids.append(vocab_item.index)
-        vocab_item.index = new_index
+    for new_index, (word, idx) in enumerate(top_vocab_list):
+        top_vector_ids.append(idx)
     top_vectors = ft.vectors[top_vector_ids, :]
     return dict(top_vocab_list), top_vectors
 

--- a/compress_fasttext/utils.py
+++ b/compress_fasttext/utils.py
@@ -3,6 +3,11 @@ import sys
 from types import ModuleType, FunctionType
 from gc import get_referents
 
+try:
+    from gensim.models.utils_any2vec import ft_ngram_hashes
+except ImportError:
+    from gensim.models.fasttext import ft_ngram_hashes
+
 # Custom objects know their class.
 # Function objects seem to know way too much, including modules.
 # Exclude modules as well.

--- a/setup.py
+++ b/setup.py
@@ -5,7 +5,7 @@ with open("README.md", "r", encoding="utf-8") as fh:
 
 setuptools.setup(
     name="compress-fasttext",
-    version="0.0.7",
+    version="0.1.0",
     author="David Dale",
     author_email="dale.david@mail.ru",
     description="A set of tools to compress gensim fasttext models",
@@ -21,7 +21,7 @@ setuptools.setup(
         "Operating System :: OS Independent",
     ],
     install_requires=[
-        'gensim<=3.8.3',
+        'gensim>=4.0.0',
         'numpy',
     ],
     extras_require={


### PR DESCRIPTION
In the 4.0.0 update, Gensim has introduced many [backward-incompatible changes](https://github.com/RaRe-Technologies/gensim/wiki/Migrating-from-Gensim-3.x-to-4), and the best way to support them seems to be making incompatible changes to `compress-fasttext` as well.

https://github.com/avidale/compress-fasttext/releases/tag/gensim-4-draft